### PR TITLE
fix sql syntax error

### DIFF
--- a/db/push_request.py
+++ b/db/push_request.py
@@ -65,8 +65,9 @@ class PRDB(BaseDB):
         where_values = []
         for key, value in kwargs.iteritems():
             if value is None:
-                where += ' and %s is %%s ORDER BY mtime DESC' % self.escape(key)
+                where += ' and %s is %%s' % self.escape(key)
             else:
-                where += ' and %s = %%s ORDER BY mtime DESC' % self.escape(key)
+                where += ' and %s = %%s' % self.escape(key)
             where_values.append(value)
+        where +=' ORDER BY mtime DESC'
         return self._select2dic(what=fields, where=where, where_values=where_values, limit=limit)


### PR DESCRIPTION
多个参数时拼接错误，例如：
``<sql: SELECT 1 FROM `push_request` WHERE 1=1 and `status` = %s ORDER BY mtime DESC and `from_tplid` = %s ORDER BY mtime DESC LIMIT 0, 100>``