### PR TITLE
更正pip安装mysql-connector-python步骤

### DIFF
--- a/web/handlers/tpl.py
+++ b/web/handlers/tpl.py
@@ -109,7 +109,10 @@ class TPLRunHandler(BaseHandler):
                 raise HTTPError(400)
 
         try:
-            result = yield self.fetcher.do_fetch(fetch_tpl, env)
+            if self.current_user:
+                result = yield self.fetcher.do_fetch(fetch_tpl, env)
+            else:
+                result = yield self.fetcher.do_fetch(fetch_tpl, env, proxies=[])
         except Exception as e:
             self.render('tpl_run_failed.html', log=e)
             return


### PR DESCRIPTION
pip安装mysql-connector-python需要 --allow-external参数
测试环境:
1. python2.7.9 ubuntu14.04 pip 6.0.6
2. python2.7.5 fedora20 pip1.5.6
