### PR TITLE
add real _cookies for jinjia template render

### DIFF
--- a/libs/fetcher.py
+++ b/libs/fetcher.py
@@ -38,11 +38,12 @@ class Fetcher(object):
 
     def render(self, request, env, session={}):
         request = dict(request)
-
+        _cookies = cookie_utils.CookieSession()
+        _cookies.from_json(session)
         def _render(obj, key):
             if not obj.get(key):
                 return
-            obj[key] = self.jinja_env.from_string(obj[key]).render(_cookies=session, **env)
+            obj[key] = self.jinja_env.from_string(obj[key]).render(_cookies=_cookies, **env)
 
         _render(request, 'method')
         _render(request, 'url')


### PR DESCRIPTION
这里提到的
https://github.com/binux/qiandao/issues/19

把session改成dict的cookies，好在jinjia template里使用