### PR TITLE
邮件配置增加使用SSL选项

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.idea
 *.pyc
 database.db
+venv/

--- a/config.py
+++ b/config.py
@@ -50,6 +50,7 @@ proxies = []
 domain = 'qiandao.today'
 
 # mailgun 邮件发送, 域名和 apikey
+mail_ssl = False
 mail_smtp = ""
 mail_user = ""
 mail_password = ""

--- a/libs/utils.py
+++ b/libs/utils.py
@@ -183,7 +183,7 @@ def _send_mail(to, subject, text=None, subtype='html'):
     msg['To'] = to
     try:
         logger.info('send mail to {}'.format(to))
-        s = smtplib.SMTP()
+        s = config.mail_ssl and smtplib.SMTP_SSL() or smtplib.SMTP()
         s.connect(config.mail_smtp)
         s.login(config.mail_user, config.mail_password)
         s.sendmail(config.mail_user, to, msg.as_string())

--- a/run.py
+++ b/run.py
@@ -38,8 +38,7 @@ if __name__ == "__main__":
     http_server.start()
 
     worker = MainWorker()
-    io_loop = IOLoop.instance()
-    PeriodicCallback(worker, config.check_task_loop, io_loop).start()
+    PeriodicCallback(worker, config.check_task_loop).start()
     worker()
 
     logging.info("http server started on %s:%s", config.bind, port)


### PR DESCRIPTION
在部署到阿里云的时候，无法发送邮件，因为阿里云屏蔽了25端口，因此只能使用SSL 465端口才能发送邮件